### PR TITLE
Fix CORS configuration for Linux environment

### DIFF
--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       - .env
     # Environment variables are now loaded from .env file
     # See .env.example for required variables
+    environment:
+      - CORS_ALLOW_ALL=true
+      - NODE_ENV=development
     volumes:
       - pong_data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
- Add CORS_ALLOW_ALL=true and NODE_ENV=development to backend service
- Ensures CORS works correctly even without .env file
- Allows access from any IP address (e.g., 10.15.4.4, 10.18.244.117)